### PR TITLE
Add descriptions to NLC classifications

### DIFF
--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -21,12 +21,11 @@
 				"Show my apps",
 				"Show me my applications.",
 				"List applications",
-				"I want to see my bluemix apps",
-				"I’d like to get a list of my apps",
+				"See my bluemix apps",
+				"Get a list of my apps",
 				"Show me my apps",
 				"What are my apps",
-				"show me my apps",
-				"how many apps do I have?",
+				"How many apps do I have?",
 				"apps"
   			]
   		},
@@ -37,7 +36,7 @@
 		   "texts": [
 			   "logs",
 			   "Show me the logs for app",
-			   "I want to browse the logs for application",
+			   "Browse the logs for application",
 			   "Check on app"
 		   ],
 	       "parameters" : [
@@ -69,9 +68,7 @@
 		   "emittarget": "bluemix.app.restage",
 		   "description": "Restage a Bluemix application",
 		   "texts": [
-			   "Restage application",
-			   "I want to restage",
-			   "I want you to restage toddForPresident"
+			   "Restage my application",
 		   ],
 	       "parameters" : [
 			   {
@@ -114,9 +111,6 @@
 		   "texts": [
 			   "Start application",
 			   "Start app",
-			   "I want to start app.",
-			   "I want to start my application",
-			   "Can you please start my app?",
 			   "kickoff app",
 			   "turn on app",
 			   "enable appliction",
@@ -136,8 +130,7 @@
 		   "description": "Show the status of a Bluemix application",
 		   "texts": [
 			   "Status of app",
-			   "I want the status of?",
-			   "what's the status of app?",
+			   "What's the status of app?",
 			   "How’s my app doing?"
 		   ],
 	       "parameters" : [

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -5,6 +5,7 @@
 		{
 			"class": "bluemix.app.help",
 	  		"emittarget": "bluemix.app.help",
+			"description": "Help with Bluemix application management",
 	  		"texts": [
 		  		"I want help with apps.",
 		  		"Can you help me with apps?",
@@ -15,6 +16,7 @@
   		{
 	  		"class": "bluemix.app.list",
 	  		"emittarget": "bluemix.app.list",
+			"description": "List Bluemix applications",
 	  		"texts": [
 				"Show my apps",
 				"Show me my applications.",
@@ -31,6 +33,7 @@
 		{
 		   "class": "bluemix.app.logs",
 		   "emittarget": "bluemix.app.logs",
+		   "description": "Show logs for a Bluemix application",
 		   "texts": [
 			   "logs",
 			   "Show me the logs for app",
@@ -48,6 +51,7 @@
 	   {
 		   "class": "bluemix.app.remove",
 		   "emittarget": "bluemix.app.remove",
+		   "description": "Remove a Bluemix application",
 		   "texts": [
 			   "Remove application",
 			   "Delete app"
@@ -63,6 +67,7 @@
 	   {
 		   "class": "bluemix.app.restage",
 		   "emittarget": "bluemix.app.restage",
+		   "description": "Restage a Bluemix application",
 		   "texts": [
 			   "Restage application",
 			   "I want to restage",
@@ -79,6 +84,7 @@
 	   {
 		   "class": "bluemix.app.scale",
 		   "emittarget": "bluemix.app.scale",
+		   "description": "Scale a Bluemix application",
 		   "texts": [
 			   "Scale application to have instances",
 			   "Add another instance to my application.",
@@ -104,6 +110,7 @@
 	   {
 		   "class": "bluemix.app.start",
 		   "emittarget": "bluemix.app.start",
+		   "description": "Start a Bluemix application",
 		   "texts": [
 			   "Start application",
 			   "Start app",
@@ -126,6 +133,7 @@
 	   {
 		   "class": "bluemix.app.status",
 		   "emittarget": "bluemix.app.status",
+		   "description": "Show the status of a Bluemix application",
 		   "texts": [
 			   "Status of app",
 			   "I want the status of?",
@@ -143,6 +151,7 @@
 	   {
 		   "class": "bluemix.app.stop",
 		   "emittarget": "bluemix.app.stop",
+		   "description": "Stop a Bluemix application",
 		   "texts": [
 			   "Stop the application",
 			   "Stop app",

--- a/src/nlc/NLC.json
+++ b/src/nlc/NLC.json
@@ -68,7 +68,7 @@
 		   "emittarget": "bluemix.app.restage",
 		   "description": "Restage a Bluemix application",
 		   "texts": [
-			   "Restage my application",
+			   "Restage my application"
 		   ],
 	       "parameters" : [
 			   {


### PR DESCRIPTION
Resolves #3 

Removes duplicate training statements and statements with generic words like “please”
